### PR TITLE
fix: add readonly arg with delegate call enabled

### DIFF
--- a/cmd/evm/t8n_test.go
+++ b/cmd/evm/t8n_test.go
@@ -369,7 +369,7 @@ func TestT9n(t *testing.T) {
 			ok, err := cmpJson(have, want)
 			switch {
 			case err != nil:
-				t.Logf(string(have))
+				t.Log(string(have))
 				t.Fatalf("test %d, json parsing failed: %v", i, err)
 			case !ok:
 				t.Fatalf("test %d: output wrong, have \n%v\nwant\n%v\n", i, string(have), string(want))
@@ -488,7 +488,7 @@ func TestB11r(t *testing.T) {
 			ok, err := cmpJson(have, want)
 			switch {
 			case err != nil:
-				t.Logf(string(have))
+				t.Log(string(have))
 				t.Fatalf("test %d, json parsing failed: %v", i, err)
 			case !ok:
 				t.Fatalf("test %d: output wrong, have \n%v\nwant\n%v\n", i, string(have), string(want))

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -391,7 +391,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 		t.Fatalf("no receipts returned")
 	} else {
 		if err := checkReceiptsRLP(rs, receipts); err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	}
 	// Delete the body and ensure that the receipts are no longer returned (metadata can't be recomputed)
@@ -401,7 +401,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 	}
 	// Ensure that receipts without metadata can be returned without the block body too
 	if err := checkReceiptsRLP(ReadRawReceipts(db, hash, 0), receipts); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	// Sanity check that body alone without the receipt is a full purge
 	WriteBody(db, hash, 0, body)

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -108,10 +108,6 @@ func (c Contract) IsPrecompile() bool {
 }
 
 func (c *Contract) validJumpdest(dest *uint256.Int) bool {
-	if c.isPrecompile {
-		return false
-	}
-
 	udest, overflow := dest.Uint64WithOverflow()
 	// PC cannot go beyond len(code) and certainly can't be bigger than 63bits.
 	// Don't bother checking for JUMPDEST in that case.
@@ -128,10 +124,6 @@ func (c *Contract) validJumpdest(dest *uint256.Int) bool {
 // isCode returns true if the provided PC location is an actual opcode, as
 // opposed to a data-segment following a PUSHN operation.
 func (c *Contract) isCode(udest uint64) bool {
-	if c.isPrecompile {
-		return false
-	}
-
 	// Do we already have an analysis laying around?
 	if c.analysis != nil {
 		return c.analysis.codeSegment(udest)
@@ -165,10 +157,6 @@ func (c *Contract) isCode(udest uint64) bool {
 // AsDelegate sets the contract to be a delegate call and returns the current
 // contract (for chaining calls)
 func (c *Contract) AsDelegate() *Contract {
-	if c.isPrecompile {
-		return c
-	}
-	// NOTE: caller must, at all times be a contract. It should never happen
 	// that caller is something other than a Contract.
 	parent := c.caller.(*Contract)
 	c.CallerAddress = parent.CallerAddress
@@ -216,10 +204,6 @@ func (c *Contract) Value() *big.Int {
 // SetCallCode sets the code of the contract and address of the backing data
 // object
 func (c *Contract) SetCallCode(addr *common.Address, hash common.Hash, code []byte) {
-	if c.isPrecompile {
-		return
-	}
-
 	c.Code = code
 	c.CodeHash = hash
 	c.CodeAddr = addr
@@ -228,10 +212,6 @@ func (c *Contract) SetCallCode(addr *common.Address, hash common.Hash, code []by
 // SetCodeOptionalHash can be used to provide code, but it's optional to provide hash.
 // In case hash is not provided, the jumpdest analysis will not be saved to the parent context
 func (c *Contract) SetCodeOptionalHash(addr *common.Address, codeAndHash *codeAndHash) {
-	if c.isPrecompile {
-		return
-	}
-
 	c.Code = codeAndHash.code
 	c.CodeHash = codeAndHash.hash
 	c.CodeAddr = addr

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -108,6 +108,10 @@ func (c Contract) IsPrecompile() bool {
 }
 
 func (c *Contract) validJumpdest(dest *uint256.Int) bool {
+	if c.isPrecompile {
+		return false
+	}
+
 	udest, overflow := dest.Uint64WithOverflow()
 	// PC cannot go beyond len(code) and certainly can't be bigger than 63bits.
 	// Don't bother checking for JUMPDEST in that case.
@@ -124,6 +128,10 @@ func (c *Contract) validJumpdest(dest *uint256.Int) bool {
 // isCode returns true if the provided PC location is an actual opcode, as
 // opposed to a data-segment following a PUSHN operation.
 func (c *Contract) isCode(udest uint64) bool {
+	if c.isPrecompile {
+		return false
+	}
+
 	// Do we already have an analysis laying around?
 	if c.analysis != nil {
 		return c.analysis.codeSegment(udest)
@@ -157,6 +165,10 @@ func (c *Contract) isCode(udest uint64) bool {
 // AsDelegate sets the contract to be a delegate call and returns the current
 // contract (for chaining calls)
 func (c *Contract) AsDelegate() *Contract {
+	if c.isPrecompile {
+		return c
+	}
+	// NOTE: caller must, at all times be a contract. It should never happen
 	// that caller is something other than a Contract.
 	parent := c.caller.(*Contract)
 	c.CallerAddress = parent.CallerAddress
@@ -204,6 +216,10 @@ func (c *Contract) Value() *big.Int {
 // SetCallCode sets the code of the contract and address of the backing data
 // object
 func (c *Contract) SetCallCode(addr *common.Address, hash common.Hash, code []byte) {
+	if c.isPrecompile {
+		return
+	}
+
 	c.Code = code
 	c.CodeHash = hash
 	c.CodeAddr = addr
@@ -212,6 +228,10 @@ func (c *Contract) SetCallCode(addr *common.Address, hash common.Hash, code []by
 // SetCodeOptionalHash can be used to provide code, but it's optional to provide hash.
 // In case hash is not provided, the jumpdest analysis will not be saved to the parent context
 func (c *Contract) SetCodeOptionalHash(addr *common.Address, codeAndHash *codeAndHash) {
+	if c.isPrecompile {
+		return
+	}
+
 	c.Code = codeAndHash.code
 	c.CodeHash = codeAndHash.hash
 	c.CodeAddr = addr

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -42,7 +42,7 @@ type PrecompiledContract interface {
 	// RequiredPrice calculates the contract gas used
 	RequiredGas(input []byte) uint64
 	// Run runs the precompiled contract
-	Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error)
+	Run(evm *EVM, contract *Contract) ([]byte, error)
 }
 
 // PrecompiledContractsHomestead contains the default set of pre-compiled Ethereum
@@ -264,19 +264,6 @@ func (evm *EVM) RunPrecompiledContract(
 	input []byte,
 	suppliedGas uint64,
 	value *big.Int,
-	readOnly bool,
-) (ret []byte, remainingGas uint64, err error) {
-	return runPrecompiledContract(evm, p, caller, input, suppliedGas, value, readOnly)
-}
-
-func runPrecompiledContract(
-	evm *EVM,
-	p PrecompiledContract,
-	caller ContractRef,
-	input []byte,
-	suppliedGas uint64,
-	value *big.Int,
-	readOnly bool,
 ) (ret []byte, remainingGas uint64, err error) {
 	addrCopy := p.Address()
 	inputCopy := make([]byte, len(input))
@@ -290,7 +277,7 @@ func runPrecompiledContract(
 		return nil, contract.Gas, ErrOutOfGas
 	}
 
-	output, err := p.Run(evm, contract, readOnly)
+	output, err := p.Run(evm, contract)
 	return output, contract.Gas, err
 }
 
@@ -307,7 +294,7 @@ func (c *ecrecover) RequiredGas(input []byte) uint64 {
 	return params.EcrecoverGas
 }
 
-func (c *ecrecover) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *ecrecover) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	const ecRecoverInputLength = 128
 
 	contract.Input = common.RightPadBytes(contract.Input, ecRecoverInputLength)
@@ -355,7 +342,7 @@ func (c *sha256hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Sha256PerWordGas + params.Sha256BaseGas
 }
 
-func (c *sha256hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *sha256hash) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	h := sha256.Sum256(contract.Input)
 	return h[:], nil
 }
@@ -377,7 +364,7 @@ func (c *ripemd160hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Ripemd160PerWordGas + params.Ripemd160BaseGas
 }
 
-func (c *ripemd160hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *ripemd160hash) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	ripemd := ripemd160.New()
 	ripemd.Write(contract.Input)
 	return common.LeftPadBytes(ripemd.Sum(nil), 32), nil
@@ -400,7 +387,7 @@ func (c *dataCopy) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
 
-func (c *dataCopy) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *dataCopy) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	return common.CopyBytes(contract.Input), nil
 }
 
@@ -534,7 +521,7 @@ func (c *bigModExp) RequiredGas(input []byte) uint64 {
 	return gas.Uint64()
 }
 
-func (c *bigModExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bigModExp) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	var (
 		baseLen = new(big.Int).SetBytes(getData(contract.Input, 0, 32)).Uint64()
 		expLen  = new(big.Int).SetBytes(getData(contract.Input, 32, 32)).Uint64()
@@ -613,7 +600,7 @@ func (c *bn256AddIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasIstanbul
 }
 
-func (c *bn256AddIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256AddIstanbul) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	return runBn256Add(contract.Input)
 }
 
@@ -632,7 +619,7 @@ func (c *bn256AddByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasByzantium
 }
 
-func (c *bn256AddByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256AddByzantium) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	return runBn256Add(contract.Input)
 }
 
@@ -663,7 +650,7 @@ func (c *bn256ScalarMulIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasIstanbul
 }
 
-func (c *bn256ScalarMulIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256ScalarMulIstanbul) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	return runBn256ScalarMul(contract.Input)
 }
 
@@ -682,7 +669,7 @@ func (c *bn256ScalarMulByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasByzantium
 }
 
-func (c *bn256ScalarMulByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256ScalarMulByzantium) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	return runBn256ScalarMul(contract.Input)
 }
 
@@ -743,7 +730,7 @@ func (c *bn256PairingIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasIstanbul + uint64(len(input)/192)*params.Bn256PairingPerPointGasIstanbul
 }
 
-func (c *bn256PairingIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256PairingIstanbul) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	return runBn256Pairing(contract.Input)
 }
 
@@ -762,7 +749,7 @@ func (c *bn256PairingByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasByzantium + uint64(len(input)/192)*params.Bn256PairingPerPointGasByzantium
 }
 
-func (c *bn256PairingByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256PairingByzantium) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	return runBn256Pairing(contract.Input)
 }
 
@@ -794,7 +781,7 @@ var (
 	errBlake2FInvalidFinalFlag   = errors.New("invalid final flag")
 )
 
-func (c *blake2F) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *blake2F) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Make sure the input is valid (correct length and final flag)
 	if len(contract.Input) != blake2FInputLength {
 		return nil, errBlake2FInvalidInputLength
@@ -854,7 +841,7 @@ func (c *bls12381G1Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1AddGas
 }
 
-func (c *bls12381G1Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G1Add) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 G1Add precompile.
 	// > G1 addition call expects `256` bytes as an input that is interpreted as byte concatenation of two G1 points (`128` bytes each).
 	// > Output is an encoding of addition operation result - single G1 point (`128` bytes).
@@ -898,7 +885,7 @@ func (c *bls12381G1Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1MulGas
 }
 
-func (c *bls12381G1Mul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G1Mul) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 G1Mul precompile.
 	// > G1 multiplication call expects `160` bytes as an input that is interpreted as byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G1 point (`128` bytes).
@@ -954,7 +941,7 @@ func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G1MulGas * discount) / 1000
 }
 
-func (c *bls12381G1MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G1MultiExp) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 G1MultiExp precompile.
 	// G1 multiplication call expects `160*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// Output is an encoding of multiexponentiation operation result - single G1 point (`128` bytes).
@@ -1003,7 +990,7 @@ func (c *bls12381G2Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2AddGas
 }
 
-func (c *bls12381G2Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G2Add) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 G2Add precompile.
 	// > G2 addition call expects `512` bytes as an input that is interpreted as byte concatenation of two G2 points (`256` bytes each).
 	// > Output is an encoding of addition operation result - single G2 point (`256` bytes).
@@ -1047,7 +1034,7 @@ func (c *bls12381G2Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2MulGas
 }
 
-func (c *bls12381G2Mul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G2Mul) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 G2MUL precompile logic.
 	// > G2 multiplication call expects `288` bytes as an input that is interpreted as byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G2 point (`256` bytes).
@@ -1103,7 +1090,7 @@ func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G2MulGas * discount) / 1000
 }
 
-func (c *bls12381G2MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G2MultiExp) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 G2MultiExp precompile logic
 	// > G2 multiplication call expects `288*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiexponentiation operation result - single G2 point (`256` bytes).
@@ -1152,7 +1139,7 @@ func (c *bls12381Pairing) RequiredGas(input []byte) uint64 {
 	return params.Bls12381PairingBaseGas + uint64(len(input)/384)*params.Bls12381PairingPerPairGas
 }
 
-func (c *bls12381Pairing) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381Pairing) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 Pairing precompile logic.
 	// > Pairing call expects `384*k` bytes as an inputs that is interpreted as byte concatenation of `k` slices. Each slice has the following structure:
 	// > - `128` bytes of G1 point encoding
@@ -1237,7 +1224,7 @@ func (c *bls12381MapG1) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG1Gas
 }
 
-func (c *bls12381MapG1) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381MapG1) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 Map_To_G1 precompile.
 	// > Field-to-curve call expects `64` bytes an an input that is interpreted as a an element of the base field.
 	// > Output of this call is `128` bytes and is G1 point following respective encoding rules.
@@ -1278,7 +1265,7 @@ func (c *bls12381MapG2) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG2Gas
 }
 
-func (c *bls12381MapG2) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381MapG2) Run(evm *EVM, contract *Contract) ([]byte, error) {
 	// Implements EIP-2537 Map_FP2_TO_G2 precompile logic.
 	// > Field-to-curve call expects `128` bytes an an input that is interpreted as a an element of the quadratic extension field.
 	// > Output of this call is `256` bytes and is G2 point following respective encoding rules.

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -42,7 +42,7 @@ type PrecompiledContract interface {
 	// RequiredPrice calculates the contract gas used
 	RequiredGas(input []byte) uint64
 	// Run runs the precompiled contract
-	Run(evm *EVM, contract *Contract) ([]byte, error)
+	Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error)
 }
 
 // PrecompiledContractsHomestead contains the default set of pre-compiled Ethereum
@@ -264,6 +264,7 @@ func (evm *EVM) RunPrecompiledContract(
 	input []byte,
 	suppliedGas uint64,
 	value *big.Int,
+	readOnly bool,
 ) (ret []byte, remainingGas uint64, err error) {
 	addrCopy := p.Address()
 	inputCopy := make([]byte, len(input))
@@ -277,7 +278,7 @@ func (evm *EVM) RunPrecompiledContract(
 		return nil, contract.Gas, ErrOutOfGas
 	}
 
-	output, err := p.Run(evm, contract)
+	output, err := p.Run(evm, contract, readOnly)
 	return output, contract.Gas, err
 }
 
@@ -294,7 +295,7 @@ func (c *ecrecover) RequiredGas(input []byte) uint64 {
 	return params.EcrecoverGas
 }
 
-func (c *ecrecover) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *ecrecover) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	const ecRecoverInputLength = 128
 
 	contract.Input = common.RightPadBytes(contract.Input, ecRecoverInputLength)
@@ -342,7 +343,7 @@ func (c *sha256hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Sha256PerWordGas + params.Sha256BaseGas
 }
 
-func (c *sha256hash) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *sha256hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	h := sha256.Sum256(contract.Input)
 	return h[:], nil
 }
@@ -364,7 +365,7 @@ func (c *ripemd160hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Ripemd160PerWordGas + params.Ripemd160BaseGas
 }
 
-func (c *ripemd160hash) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *ripemd160hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	ripemd := ripemd160.New()
 	ripemd.Write(contract.Input)
 	return common.LeftPadBytes(ripemd.Sum(nil), 32), nil
@@ -387,7 +388,7 @@ func (c *dataCopy) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
 
-func (c *dataCopy) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *dataCopy) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	return common.CopyBytes(contract.Input), nil
 }
 
@@ -521,7 +522,7 @@ func (c *bigModExp) RequiredGas(input []byte) uint64 {
 	return gas.Uint64()
 }
 
-func (c *bigModExp) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bigModExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	var (
 		baseLen = new(big.Int).SetBytes(getData(contract.Input, 0, 32)).Uint64()
 		expLen  = new(big.Int).SetBytes(getData(contract.Input, 32, 32)).Uint64()
@@ -600,7 +601,7 @@ func (c *bn256AddIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasIstanbul
 }
 
-func (c *bn256AddIstanbul) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bn256AddIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	return runBn256Add(contract.Input)
 }
 
@@ -619,7 +620,7 @@ func (c *bn256AddByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasByzantium
 }
 
-func (c *bn256AddByzantium) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bn256AddByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	return runBn256Add(contract.Input)
 }
 
@@ -650,7 +651,7 @@ func (c *bn256ScalarMulIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasIstanbul
 }
 
-func (c *bn256ScalarMulIstanbul) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bn256ScalarMulIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	return runBn256ScalarMul(contract.Input)
 }
 
@@ -669,7 +670,7 @@ func (c *bn256ScalarMulByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasByzantium
 }
 
-func (c *bn256ScalarMulByzantium) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bn256ScalarMulByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	return runBn256ScalarMul(contract.Input)
 }
 
@@ -730,7 +731,7 @@ func (c *bn256PairingIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasIstanbul + uint64(len(input)/192)*params.Bn256PairingPerPointGasIstanbul
 }
 
-func (c *bn256PairingIstanbul) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bn256PairingIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	return runBn256Pairing(contract.Input)
 }
 
@@ -749,7 +750,7 @@ func (c *bn256PairingByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasByzantium + uint64(len(input)/192)*params.Bn256PairingPerPointGasByzantium
 }
 
-func (c *bn256PairingByzantium) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bn256PairingByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	return runBn256Pairing(contract.Input)
 }
 
@@ -781,7 +782,7 @@ var (
 	errBlake2FInvalidFinalFlag   = errors.New("invalid final flag")
 )
 
-func (c *blake2F) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *blake2F) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Make sure the input is valid (correct length and final flag)
 	if len(contract.Input) != blake2FInputLength {
 		return nil, errBlake2FInvalidInputLength
@@ -841,7 +842,7 @@ func (c *bls12381G1Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1AddGas
 }
 
-func (c *bls12381G1Add) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381G1Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G1Add precompile.
 	// > G1 addition call expects `256` bytes as an input that is interpreted as byte concatenation of two G1 points (`128` bytes each).
 	// > Output is an encoding of addition operation result - single G1 point (`128` bytes).
@@ -885,7 +886,7 @@ func (c *bls12381G1Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1MulGas
 }
 
-func (c *bls12381G1Mul) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381G1Mul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G1Mul precompile.
 	// > G1 multiplication call expects `160` bytes as an input that is interpreted as byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G1 point (`128` bytes).
@@ -941,7 +942,7 @@ func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G1MulGas * discount) / 1000
 }
 
-func (c *bls12381G1MultiExp) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381G1MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G1MultiExp precompile.
 	// G1 multiplication call expects `160*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// Output is an encoding of multiexponentiation operation result - single G1 point (`128` bytes).
@@ -990,7 +991,7 @@ func (c *bls12381G2Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2AddGas
 }
 
-func (c *bls12381G2Add) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381G2Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G2Add precompile.
 	// > G2 addition call expects `512` bytes as an input that is interpreted as byte concatenation of two G2 points (`256` bytes each).
 	// > Output is an encoding of addition operation result - single G2 point (`256` bytes).
@@ -1034,7 +1035,7 @@ func (c *bls12381G2Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2MulGas
 }
 
-func (c *bls12381G2Mul) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381G2Mul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G2MUL precompile logic.
 	// > G2 multiplication call expects `288` bytes as an input that is interpreted as byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G2 point (`256` bytes).
@@ -1090,7 +1091,7 @@ func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G2MulGas * discount) / 1000
 }
 
-func (c *bls12381G2MultiExp) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381G2MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G2MultiExp precompile logic
 	// > G2 multiplication call expects `288*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiexponentiation operation result - single G2 point (`256` bytes).
@@ -1139,7 +1140,7 @@ func (c *bls12381Pairing) RequiredGas(input []byte) uint64 {
 	return params.Bls12381PairingBaseGas + uint64(len(input)/384)*params.Bls12381PairingPerPairGas
 }
 
-func (c *bls12381Pairing) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381Pairing) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 Pairing precompile logic.
 	// > Pairing call expects `384*k` bytes as an inputs that is interpreted as byte concatenation of `k` slices. Each slice has the following structure:
 	// > - `128` bytes of G1 point encoding
@@ -1224,7 +1225,7 @@ func (c *bls12381MapG1) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG1Gas
 }
 
-func (c *bls12381MapG1) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381MapG1) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 Map_To_G1 precompile.
 	// > Field-to-curve call expects `64` bytes an an input that is interpreted as a an element of the base field.
 	// > Output of this call is `128` bytes and is G1 point following respective encoding rules.
@@ -1265,7 +1266,7 @@ func (c *bls12381MapG2) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG2Gas
 }
 
-func (c *bls12381MapG2) Run(evm *EVM, contract *Contract) ([]byte, error) {
+func (c *bls12381MapG2) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 Map_FP2_TO_G2 precompile logic.
 	// > Field-to-curve call expects `128` bytes an an input that is interpreted as a an element of the quadratic extension field.
 	// > Output of this call is `256` bytes and is G2 point following respective encoding rules.

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -98,7 +98,7 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	gas := p.RequiredGas(in)
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
 		if res, _, err := new(EVM).RunPrecompiledContract(
-			p, AccountRef(common.Address{}), in, gas, new(big.Int),
+			p, AccountRef(common.Address{}), in, gas, new(big.Int), false,
 		); err != nil {
 			t.Error(err)
 		} else if common.Bytes2Hex(res) != test.Expected {
@@ -122,7 +122,7 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
 		_, _, err := new(EVM).RunPrecompiledContract(
-			p, AccountRef(common.Address{}), in, gas, new(big.Int),
+			p, AccountRef(common.Address{}), in, gas, new(big.Int), false,
 		)
 		if err.Error() != "out of gas" {
 			t.Errorf("Expected error [out of gas], got [%v]", err)
@@ -141,7 +141,7 @@ func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing
 	gas := p.RequiredGas(in)
 	t.Run(test.Name, func(t *testing.T) {
 		_, _, err := new(EVM).RunPrecompiledContract(
-			p, AccountRef(common.Address{}), in, gas, new(big.Int),
+			p, AccountRef(common.Address{}), in, gas, new(big.Int), false,
 		)
 		if err.Error() != test.ExpectedError {
 			t.Errorf("Expected error [%v], got [%v]", test.ExpectedError, err)
@@ -175,7 +175,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		for i := 0; i < bench.N; i++ {
 			copy(data, in)
 			res, _, err = new(EVM).RunPrecompiledContract(
-				p, AccountRef(common.Address{}), in, reqGas, new(big.Int),
+				p, AccountRef(common.Address{}), in, reqGas, new(big.Int), false,
 			)
 		}
 		bench.StopTimer()

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -97,7 +97,9 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		if res, _, err := runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, gas, new(big.Int), false); err != nil {
+		if res, _, err := new(EVM).RunPrecompiledContract(
+			p, AccountRef(common.Address{}), in, gas, new(big.Int),
+		); err != nil {
 			t.Error(err)
 		} else if common.Bytes2Hex(res) != test.Expected {
 			t.Errorf("Expected %v, got %v", test.Expected, common.Bytes2Hex(res))
@@ -119,7 +121,9 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 	gas := p.RequiredGas(in) - 1
 
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		_, _, err := runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, gas, new(big.Int), false)
+		_, _, err := new(EVM).RunPrecompiledContract(
+			p, AccountRef(common.Address{}), in, gas, new(big.Int),
+		)
 		if err.Error() != "out of gas" {
 			t.Errorf("Expected error [out of gas], got [%v]", err)
 		}
@@ -136,7 +140,9 @@ func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(test.Name, func(t *testing.T) {
-		_, _, err := runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, gas, new(big.Int), false)
+		_, _, err := new(EVM).RunPrecompiledContract(
+			p, AccountRef(common.Address{}), in, gas, new(big.Int),
+		)
 		if err.Error() != test.ExpectedError {
 			t.Errorf("Expected error [%v], got [%v]", test.ExpectedError, err)
 		}
@@ -168,7 +174,9 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		bench.ResetTimer()
 		for i := 0; i < bench.N; i++ {
 			copy(data, in)
-			res, _, err = runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, reqGas, new(big.Int), false)
+			res, _, err = new(EVM).RunPrecompiledContract(
+				p, AccountRef(common.Address{}), in, reqGas, new(big.Int),
+			)
 		}
 		bench.StopTimer()
 		elapsed := uint64(time.Since(start))

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -210,7 +210,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 
 	// It is allowed to call precompiles, even via call -- as opposed to callcode, staticcall and delegatecall it can also modify state
 	if isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value, false)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -271,9 +271,9 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 		}(gas)
 	}
 
-	// It is allowed to call precompiles, even via callcode, but only for reading
+	// It is allowed to call precompiles, even via callcode
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value, true)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -314,7 +314,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, nil, true)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, nil)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
@@ -364,7 +364,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
 		// Note: delegate call is not allowed to modify state on precompiles
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, new(big.Int), true)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, new(big.Int))
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -210,7 +210,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 
 	// It is allowed to call precompiles, even via call -- as opposed to callcode, staticcall and delegatecall it can also modify state
 	if isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value, false)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -273,13 +273,15 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via callcode
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value, false)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		contract := NewContract(caller, AccountRef(caller.Address()), value, gas)
-		contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
+		contract.SetCallCode(
+			&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy),
+		)
 		ret, err = evm.interpreter.Run(contract, input, false)
 		gas = contract.Gas
 	}
@@ -314,7 +316,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, nil)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, nil, false)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
@@ -363,7 +365,8 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, new(big.Int))
+		// Note: delegate call is not allowed to modify state on precompiles
+		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, new(big.Int), true)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -363,7 +363,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		// Note: delegate call is not allowed to modify state on precompiles
 		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, new(big.Int))
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -172,9 +172,7 @@ func (l *StructLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, s
 	var stck []uint256.Int
 	if !l.cfg.DisableStack {
 		stck = make([]uint256.Int, len(stack.Data))
-		for i, item := range stack.Data {
-			stck[i] = item
-		}
+		copy(stck, stack.Data)
 	}
 	stackData := stack.Data
 	stackLen := len(stackData)

--- a/metrics/json_test.go
+++ b/metrics/json_test.go
@@ -13,7 +13,7 @@ func TestRegistryMarshallJSON(t *testing.T) {
 	r.Register("counter", NewCounter())
 	enc.Encode(r)
 	if s := b.String(); s != "{\"counter\":{\"count\":0}}\n" {
-		t.Fatalf(s)
+		t.Fatal(s)
 	}
 }
 

--- a/tests/fuzzers/bls12381/precompile_fuzzer.go
+++ b/tests/fuzzers/bls12381/precompile_fuzzer.go
@@ -94,7 +94,7 @@ func fuzz(id byte, data []byte) int {
 	copy(cpy, data)
 	contract := vm.NewPrecompile(vm.AccountRef(common.Address{}), precompile, common.Big0, gas)
 	contract.Input = cpy
-	_, err := precompile.Run(nil, contract, false)
+	_, err := precompile.Run(nil, contract)
 	if !bytes.Equal(cpy, data) {
 		panic(fmt.Sprintf("input data modified, precompile %d: %x %x", id, data, cpy))
 	}

--- a/tests/fuzzers/bls12381/precompile_fuzzer.go
+++ b/tests/fuzzers/bls12381/precompile_fuzzer.go
@@ -94,7 +94,7 @@ func fuzz(id byte, data []byte) int {
 	copy(cpy, data)
 	contract := vm.NewPrecompile(vm.AccountRef(common.Address{}), precompile, common.Big0, gas)
 	contract.Input = cpy
-	_, err := precompile.Run(nil, contract)
+	_, err := precompile.Run(nil, contract, false)
 	if !bytes.Equal(cpy, data) {
 		panic(fmt.Sprintf("input data modified, precompile %d: %x %x", id, data, cpy))
 	}


### PR DESCRIPTION
## v1.10.29-nibiru

- **fix: add readonly arg with delegate call enabled v1.10.29-nibiru**

## v1.10.28-nibiru

- **refactor!: Remove readonly parameter in RunPrecompiledContract and bring the implementation closer to standard geth**
- **refactor!: Sync behavior closer to upstream geth**