### PR TITLE
feat: extend RunPrecompiledContract

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -42,7 +42,7 @@ type PrecompiledContract interface {
 	// RequiredPrice calculates the contract gas used
 	RequiredGas(input []byte) uint64
 	// Run runs the precompiled contract
-	Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error)
+	Run(evm *EVM, sender common.Address, contract *Contract, readonly bool, calledFromDelegateCall bool) ([]byte, error)
 }
 
 // PrecompiledContractsHomestead contains the default set of pre-compiled Ethereum
@@ -260,11 +260,13 @@ func ValidatePrecompiles(
 // - any error that occurred
 func (evm *EVM) RunPrecompiledContract(
 	p PrecompiledContract,
+	sender common.Address,
 	caller ContractRef,
 	input []byte,
 	suppliedGas uint64,
 	value *big.Int,
 	readOnly bool,
+	calledFromDelegateCall bool,
 ) (ret []byte, remainingGas uint64, err error) {
 	addrCopy := p.Address()
 	inputCopy := make([]byte, len(input))
@@ -278,7 +280,7 @@ func (evm *EVM) RunPrecompiledContract(
 		return nil, contract.Gas, ErrOutOfGas
 	}
 
-	output, err := p.Run(evm, contract, readOnly)
+	output, err := p.Run(evm, sender, contract, readOnly, calledFromDelegateCall)
 	return output, contract.Gas, err
 }
 
@@ -295,7 +297,7 @@ func (c *ecrecover) RequiredGas(input []byte) uint64 {
 	return params.EcrecoverGas
 }
 
-func (c *ecrecover) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *ecrecover) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	const ecRecoverInputLength = 128
 
 	contract.Input = common.RightPadBytes(contract.Input, ecRecoverInputLength)
@@ -343,7 +345,7 @@ func (c *sha256hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Sha256PerWordGas + params.Sha256BaseGas
 }
 
-func (c *sha256hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *sha256hash) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	h := sha256.Sum256(contract.Input)
 	return h[:], nil
 }
@@ -365,7 +367,7 @@ func (c *ripemd160hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Ripemd160PerWordGas + params.Ripemd160BaseGas
 }
 
-func (c *ripemd160hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *ripemd160hash) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	ripemd := ripemd160.New()
 	ripemd.Write(contract.Input)
 	return common.LeftPadBytes(ripemd.Sum(nil), 32), nil
@@ -388,7 +390,7 @@ func (c *dataCopy) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
 
-func (c *dataCopy) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *dataCopy) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	return common.CopyBytes(contract.Input), nil
 }
 
@@ -522,7 +524,7 @@ func (c *bigModExp) RequiredGas(input []byte) uint64 {
 	return gas.Uint64()
 }
 
-func (c *bigModExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bigModExp) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	var (
 		baseLen = new(big.Int).SetBytes(getData(contract.Input, 0, 32)).Uint64()
 		expLen  = new(big.Int).SetBytes(getData(contract.Input, 32, 32)).Uint64()
@@ -601,7 +603,7 @@ func (c *bn256AddIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasIstanbul
 }
 
-func (c *bn256AddIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256AddIstanbul) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	return runBn256Add(contract.Input)
 }
 
@@ -620,7 +622,7 @@ func (c *bn256AddByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasByzantium
 }
 
-func (c *bn256AddByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256AddByzantium) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	return runBn256Add(contract.Input)
 }
 
@@ -651,7 +653,7 @@ func (c *bn256ScalarMulIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasIstanbul
 }
 
-func (c *bn256ScalarMulIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256ScalarMulIstanbul) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	return runBn256ScalarMul(contract.Input)
 }
 
@@ -670,7 +672,7 @@ func (c *bn256ScalarMulByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasByzantium
 }
 
-func (c *bn256ScalarMulByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256ScalarMulByzantium) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	return runBn256ScalarMul(contract.Input)
 }
 
@@ -731,7 +733,7 @@ func (c *bn256PairingIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasIstanbul + uint64(len(input)/192)*params.Bn256PairingPerPointGasIstanbul
 }
 
-func (c *bn256PairingIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256PairingIstanbul) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	return runBn256Pairing(contract.Input)
 }
 
@@ -750,7 +752,7 @@ func (c *bn256PairingByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasByzantium + uint64(len(input)/192)*params.Bn256PairingPerPointGasByzantium
 }
 
-func (c *bn256PairingByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bn256PairingByzantium) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	return runBn256Pairing(contract.Input)
 }
 
@@ -782,7 +784,7 @@ var (
 	errBlake2FInvalidFinalFlag   = errors.New("invalid final flag")
 )
 
-func (c *blake2F) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *blake2F) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Make sure the input is valid (correct length and final flag)
 	if len(contract.Input) != blake2FInputLength {
 		return nil, errBlake2FInvalidInputLength
@@ -842,7 +844,7 @@ func (c *bls12381G1Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1AddGas
 }
 
-func (c *bls12381G1Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G1Add) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 G1Add precompile.
 	// > G1 addition call expects `256` bytes as an input that is interpreted as byte concatenation of two G1 points (`128` bytes each).
 	// > Output is an encoding of addition operation result - single G1 point (`128` bytes).
@@ -886,7 +888,7 @@ func (c *bls12381G1Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1MulGas
 }
 
-func (c *bls12381G1Mul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G1Mul) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 G1Mul precompile.
 	// > G1 multiplication call expects `160` bytes as an input that is interpreted as byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G1 point (`128` bytes).
@@ -942,7 +944,7 @@ func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G1MulGas * discount) / 1000
 }
 
-func (c *bls12381G1MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G1MultiExp) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 G1MultiExp precompile.
 	// G1 multiplication call expects `160*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// Output is an encoding of multiexponentiation operation result - single G1 point (`128` bytes).
@@ -991,7 +993,7 @@ func (c *bls12381G2Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2AddGas
 }
 
-func (c *bls12381G2Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G2Add) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 G2Add precompile.
 	// > G2 addition call expects `512` bytes as an input that is interpreted as byte concatenation of two G2 points (`256` bytes each).
 	// > Output is an encoding of addition operation result - single G2 point (`256` bytes).
@@ -1035,7 +1037,7 @@ func (c *bls12381G2Mul) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2MulGas
 }
 
-func (c *bls12381G2Mul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G2Mul) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 G2MUL precompile logic.
 	// > G2 multiplication call expects `288` bytes as an input that is interpreted as byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiplication operation result - single G2 point (`256` bytes).
@@ -1091,7 +1093,7 @@ func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G2MulGas * discount) / 1000
 }
 
-func (c *bls12381G2MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381G2MultiExp) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 G2MultiExp precompile logic
 	// > G2 multiplication call expects `288*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiexponentiation operation result - single G2 point (`256` bytes).
@@ -1140,7 +1142,7 @@ func (c *bls12381Pairing) RequiredGas(input []byte) uint64 {
 	return params.Bls12381PairingBaseGas + uint64(len(input)/384)*params.Bls12381PairingPerPairGas
 }
 
-func (c *bls12381Pairing) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381Pairing) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 Pairing precompile logic.
 	// > Pairing call expects `384*k` bytes as an inputs that is interpreted as byte concatenation of `k` slices. Each slice has the following structure:
 	// > - `128` bytes of G1 point encoding
@@ -1225,7 +1227,7 @@ func (c *bls12381MapG1) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG1Gas
 }
 
-func (c *bls12381MapG1) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381MapG1) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 Map_To_G1 precompile.
 	// > Field-to-curve call expects `64` bytes an an input that is interpreted as a an element of the base field.
 	// > Output of this call is `128` bytes and is G1 point following respective encoding rules.
@@ -1266,7 +1268,7 @@ func (c *bls12381MapG2) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG2Gas
 }
 
-func (c *bls12381MapG2) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+func (c *bls12381MapG2) Run(evm *EVM, _ common.Address, contract *Contract, readonly bool, _ bool) ([]byte, error) {
 	// Implements EIP-2537 Map_FP2_TO_G2 precompile logic.
 	// > Field-to-curve call expects `128` bytes an an input that is interpreted as a an element of the quadratic extension field.
 	// > Output of this call is `256` bytes and is G2 point following respective encoding rules.

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -98,7 +98,7 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	gas := p.RequiredGas(in)
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
 		if res, _, err := new(EVM).RunPrecompiledContract(
-			p, AccountRef(common.Address{}), in, gas, new(big.Int), false,
+			p, common.Address{}, AccountRef(common.Address{}), in, gas, new(big.Int), false, false,
 		); err != nil {
 			t.Error(err)
 		} else if common.Bytes2Hex(res) != test.Expected {
@@ -122,7 +122,7 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
 		_, _, err := new(EVM).RunPrecompiledContract(
-			p, AccountRef(common.Address{}), in, gas, new(big.Int), false,
+			p, common.Address{}, AccountRef(common.Address{}), in, gas, new(big.Int), false, false,
 		)
 		if err.Error() != "out of gas" {
 			t.Errorf("Expected error [out of gas], got [%v]", err)
@@ -141,7 +141,7 @@ func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing
 	gas := p.RequiredGas(in)
 	t.Run(test.Name, func(t *testing.T) {
 		_, _, err := new(EVM).RunPrecompiledContract(
-			p, AccountRef(common.Address{}), in, gas, new(big.Int), false,
+			p, common.Address{}, AccountRef(common.Address{}), in, gas, new(big.Int), false, false,
 		)
 		if err.Error() != test.ExpectedError {
 			t.Errorf("Expected error [%v], got [%v]", test.ExpectedError, err)
@@ -175,7 +175,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		for i := 0; i < bench.N; i++ {
 			copy(data, in)
 			res, _, err = new(EVM).RunPrecompiledContract(
-				p, AccountRef(common.Address{}), in, reqGas, new(big.Int), false,
+				p, common.Address{}, AccountRef(common.Address{}), in, reqGas, new(big.Int), false, false,
 			)
 		}
 		bench.StopTimer()

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -210,7 +210,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 
 	// It is allowed to call precompiles, even via call -- as opposed to callcode, staticcall and delegatecall it can also modify state
 	if isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value, false)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller.Address(), caller, input, gas, value, false, false)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -273,7 +273,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 
 	// It is allowed to call precompiles, even via callcode
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, value, false)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller.Address(), caller, input, gas, value, false, false)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
@@ -316,7 +316,9 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// It is allowed to call precompiles, even via delegatecall
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, nil, false)
+		parent := caller.(*Contract)
+
+		ret, gas, err = evm.RunPrecompiledContract(p, parent.CallerAddress, caller, input, gas, nil, false, true)
 	} else {
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
@@ -366,7 +368,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 
 	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
 		// Note: delegate call is not allowed to modify state on precompiles
-		ret, gas, err = evm.RunPrecompiledContract(p, caller, input, gas, new(big.Int), true)
+		ret, gas, err = evm.RunPrecompiledContract(p, caller.Address(), caller, input, gas, new(big.Int), true, false)
 	} else {
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'


### PR DESCRIPTION
This pull request includes several changes to the `core/vm/contracts.go` file, primarily focused on modifying the `Run` method signatures for various precompiled contracts. The changes introduce new parameters to the `Run` method and update the corresponding method calls throughout the codebase.

### Changes to `Run` method signatures:

* [`core/vm/contracts.go`](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL45-R45): Updated the `Run` method signatures for precompiled contracts to include `sender` and `calledFromDelegateCall` parameters. This change affects multiple precompiled contract implementations, including `ecrecover`, `sha256hash`, `ripemd160hash`, `dataCopy`, `bigModExp`, `bn256AddIstanbul`, `bn256AddByzantium`, `bn256ScalarMulIstanbul`, `bn256ScalarMulByzantium`, `bn256PairingIstanbul`, `bn256PairingByzantium`, `blake2F`, `bls12381G1Add`, `bls12381G1Mul`, `bls12381G1MultiExp`, `bls12381G2Add`, `bls12381G2Mul`, `bls12381G2MultiExp`, `bls12381Pairing`, `bls12381MapG1`, and `bls12381MapG2`. [[1]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL45-R45) [[2]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL298-R300) [[3]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL346-R348) [[4]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL368-R370) [[5]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL391-R393) [[6]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL525-R527) [[7]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL604-R606) [[8]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL623-R625) [[9]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL654-R656) [[10]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL673-R675) [[11]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL734-R736) [[12]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL753-R755) [[13]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL785-R787) [[14]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL845-R847) [[15]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL889-R891) [[16]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL945-R947) [[17]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL994-R996) [[18]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL1038-R1040) [[19]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL1094-R1096) [[20]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL1143-R1145) [[21]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL1228-R1230) [[22]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL1269-R1271)

### Updates to method calls:

* [`core/vm/contracts.go`](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fR263-R269): Updated the `RunPrecompiledContract` method to pass the new `sender` and `calledFromDelegateCall` parameters when calling the `Run` method. [[1]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fR263-R269) [[2]](diffhunk://#diff-8403dffcbec1accad5356c19a66853e9c4cf77a1a11a2d9eeb73ed0c2022257fL281-R283)
* [`core/vm/contracts_test.go`](diffhunk://#diff-b8e213cc8b44bc7d5d5e727524d63e19dd0f21312713ce2471948d1f64db212cL101-R101): Updated test functions to include the new parameters in calls to `RunPrecompiledContract`. [[1]](diffhunk://#diff-b8e213cc8b44bc7d5d5e727524d63e19dd0f21312713ce2471948d1f64db212cL101-R101) [[2]](diffhunk://#diff-b8e213cc8b44bc7d5d5e727524d63e19dd0f21312713ce2471948d1f64db212cL125-R125) [[3]](diffhunk://#diff-b8e213cc8b44bc7d5d5e727524d63e19dd0f21312713ce2471948d1f64db212cL144-R144) [[4]](diffhunk://#diff-b8e213cc8b44bc7d5d5e727524d63e19dd0f21312713ce2471948d1f64db212cL178-R178)
* [`core/vm/evm.go`](diffhunk://#diff-64508d317d86e7a4a5294d76455a5e74148e26883da9e8b4ffc9bbfa3cc8550eL213-R213): Updated the `Call` and `CallCode` methods to include the new parameters in calls to `RunPrecompiledContract`. [[1]](diffhunk://#diff-64508d317d86e7a4a5294d76455a5e74148e26883da9e8b4ffc9bbfa3cc8550eL213-R213) [[2]](diffhunk://#diff-64508d317d86e7a4a5294d76455a5e74148e26883da9e8b4ffc9bbfa3cc8550eL276-R276)