### PR TITLE
fix(nibiru-hygiene): enable CI tests, check builds, and fix all tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,6 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-accounts/usbwallet              @karalabe
-accounts/scwallet               @gballet
-accounts/abi                    @gballet @MariusVanDerWijden
-beacon/engine                   @lightclient
-cmd/clef                        @holiman
-cmd/evm                         @holiman @MariusVanDerWijden @lightclient
-consensus                       @karalabe
-core/                           @karalabe @holiman @rjl493456442
-eth/                            @karalabe @holiman @rjl493456442
-eth/catalyst/                   @gballet @lightclient
-eth/tracers/                    @s1na
-core/tracing/                   @s1na
-graphql/                        @s1na
-internal/ethapi                 @lightclient
-internal/era                    @lightclient
-les/                            @zsfelfoldi @rjl493456442
-light/                          @zsfelfoldi @rjl493456442
-node/                           @fjl
-p2p/                            @fjl @zsfelfoldi
-params/                         @fjl @holiman @karalabe @gballet @rjl493456442 @zsfelfoldi
-rpc/                            @fjl @holiman
-signer/                         @holiman
+# Gives the team, https://github.com/orgs/NibiruChain/teams/backend, ownership of
+# the entire repository.
+*                 @NibiruChain/backend

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,24 +1,38 @@
-name: i386 linux tests
+name: Go Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: ["nibiru/geth", "master", "nibiru/**"]
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
 
+# Allow concurrent runs on certain branches: [nibiru/geth, release/*]
+# but isolate all other branches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/nibiru/geth' || startsWith(github.ref, 'refs/heads/release/')) }}
+
 jobs:
-  build:
-    runs-on: self-hosted
+  go-tests:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
-          cache: false
+          go-version: 1.24
+          cache: true
+
+      - name: "Install just"
+        # casey/just: https://just.systems/man/en/chapter_6.html
+        # taiki-e/install-action: https://github.com/taiki-e/install-action
+        uses: taiki-e/install-action@just
+
+      - name: "Run go build ./..."
+        run: just test-build
+
       - name: Run tests
-        run: go test -short ./...
+        run: just test-unit
         env:
           GOOS: linux
           GOARCH: 386

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,15 +24,33 @@ jobs:
           cache: true
 
       - name: "Install just"
+        uses: taiki-e/install-action@just
         # casey/just: https://just.systems/man/en/chapter_6.html
         # taiki-e/install-action: https://github.com/taiki-e/install-action
-        uses: taiki-e/install-action@just
-
-      - name: "Run go build ./..."
-        run: just test-build
 
       - name: Run tests
         run: just test-unit
+        env:
+          GOOS: linux
+          GOARCH: 386
+
+  go-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+          cache: true
+
+      - name: "Install just"
+        uses: taiki-e/install-action@just
+        # casey/just: https://just.systems/man/en/chapter_6.html
+        # taiki-e/install-action: https://github.com/taiki-e/install-action
+
+      - name: "Run go build ./..."
+        run: just test-build
         env:
           GOOS: linux
           GOARCH: 386

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,9 +23,8 @@ jobs:
           go-version: 1.24
           cache: true
 
-      - name: "Install just"
+      - name: "Install just" # casey/just: https://just.systems/man/en/chapter_6.html
         uses: taiki-e/install-action@just
-        # casey/just: https://just.systems/man/en/chapter_6.html
         # taiki-e/install-action: https://github.com/taiki-e/install-action
 
       - name: Run tests
@@ -44,9 +43,8 @@ jobs:
           go-version: 1.24
           cache: true
 
-      - name: "Install just"
+      - name: "Install just" # casey/just: https://just.systems/man/en/chapter_6.html
         uses: taiki-e/install-action@just
-        # casey/just: https://just.systems/man/en/chapter_6.html
         # taiki-e/install-action: https://github.com/taiki-e/install-action
 
       - name: "Run go build ./..."

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -164,10 +164,8 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 		AccessList:       tx.AccessList(),
 		SkipNonceChecks:  false,
 		SkipFromEOACheck: false,
-		BlobHashes:       nil,
-		BlobGasFeeCap:    nil,
-		// BlobHashes:       tx.BlobHashes(),
-		// BlobGasFeeCap:    tx.BlobGasFeeCap(),
+		BlobHashes:       tx.BlobHashes(),
+		BlobGasFeeCap:    tx.BlobGasFeeCap(),
 	}
 	// If baseFee provided, set gasPrice to effectiveGasPrice.
 	if baseFee != nil {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -18,7 +18,6 @@ package vm
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"sync/atomic"
 
@@ -616,7 +615,6 @@ func (evm *EVM) captureBegin(depth int, typ OpCode, from common.Address, to comm
 	if tracer.OnGasChange != nil {
 		tracer.OnGasChange(0, startGas, tracing.GasChangeCallInitialBalance)
 	}
-	fmt.Printf("TODO: UD-DEBUG: EVM.captureBegin: tracer.OnEnter: %T, tracer.OnGasChange: %T, tracer.OnExit: %T", tracer.OnEnter, tracer.OnGasChange, tracer.OnExit)
 }
 
 func (evm *EVM) captureEnd(depth int, startGas uint64, leftOverGas uint64, ret []byte, err error) {

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+# Displays available recipes by running `just -l`.
+setup:
+  #!/usr/bin/env bash
+  just -l
+
+# Run Go tests (short mode)
+test-unit:
+  go test -short $(go list ./... \
+    | grep -v '^github\.com/ethereum/go-ethereum/cmd/')
+
+
+# Run go build to make sure Nibiru can import this dependency
+test-build:
+  go build ./...

--- a/justfile
+++ b/justfile
@@ -5,8 +5,13 @@ setup:
 
 # Run Go tests (short mode)
 test-unit:
-  go test -short $(go list ./... \
-    | grep -v '^github\.com/ethereum/go-ethereum/cmd/')
+  go test -short ./...
+
+  # Uncomment the below code to filter out certain paths during upgrades to newer
+  # versions in the [upstream repository](github.com/ethereum/go-ethereum).
+  # 
+  # go test -short $(go list ./... \
+  #   | grep -v '^github\.com/ethereum/go-ethereum/cmd/')
 
 
 # Run go build to make sure Nibiru can import this dependency


### PR DESCRIPTION
## Motivation

Bring our fork fully in line with upstream, automate testing on GitHub Actions,
and knock out lingering debug code so every test passes cleanly.

## Summary of changes
- **Ownership**  
  - Collapse `.github/CODEOWNERS` to grant `@NibiruChain/backend` ownership of the repo.  
- **CI pipeline**  
  - Revamp `.github/workflows/go.yml`  
    - Rename job to “Go Tests”  
    - Trigger on `nibiru/geth`, `master`, and `nibiru/**` branches  
    - Add concurrency rules to isolate runs on feature branches  
    - Bump Go to 1.24 and enable module caching  
    - Install and invoke `just` recipes for build & test  
  - Add a `justfile` with `test-build` and `test-unit` recipes  
- **Bugfix: blob fields**  
  - In `core/state_transition.go`, restore `BlobHashes` and `BlobGasFeeCap` so header hashes match upstream and RPC tests pass  
- **Cleanup**  
  - Remove the stray `fmt.Printf` debug line from `core/vm/evm.go` and drop its import  

## Testing

All tests now pass on Ubuntu-latest with Go 1.24, and CI is green.

```bash
just test-build   # verifies go build ./...
just test-unit    # runs `go test -short` against all packages except cmd/
```  

